### PR TITLE
Added xdebug for IDEs to listen to 9001

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
             DB_NAME: 'uk_restaurant_local'
         volumes:
             - ./:/var/www/vhost/:cached
+            - ./docker/php/local.ini:/usr/local/etc/php/conf.d/local.ini
         ports:
             - '9000:9000'
         networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
             DB_USER: 'root'
             DB_PASSWORD: 'root'
             DB_NAME: 'uk_restaurant_local'
+            PHP_IDE_CONFIG: 'serverName=uk-restaurants.test'
         volumes:
             - ./:/var/www/vhost/:cached
             - ./docker/php/local.ini:/usr/local/etc/php/conf.d/local.ini

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get clean && apt-get update && apt-get upgrade -y && apt-get install -y 
 
 RUN docker-php-source extract && \
     pecl install redis && \
+    pecl install xdebug && \
     pecl install imagick && \
     docker-php-ext-enable imagick && \
     docker-php-ext-enable redis && \

--- a/docker/php/local.ini
+++ b/docker/php/local.ini
@@ -1,0 +1,5 @@
+zend_extension=xdebug
+xdebug.remote_enable=1
+xdebug.remote_autostart=1
+xdebug.remote_port=9001
+xdebug.remote_host=host.docker.internal


### PR DESCRIPTION
This uses a local docker IP reference, we might need to change this to make it cross platform.